### PR TITLE
fix: align frontend with backend API — endpoints, types, and admin fe…

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -69,12 +69,12 @@ function NavSection({ title, items }: { title: string; items: NavItem[] }) {
 }
 
 export function Sidebar() {
-  const { user, isAdmin, isOwner, shops, shopId, setActiveShop, logout } = useAuth();
+  const { user, isAdmin, isOwner, isMechanic, shops, shopId, setActiveShop, logout } = useAuth();
 
-  const showShopSection = isAdmin || isOwner;
-  const shopNav = OWNER_NAV; // All owner pages are visible to both admin and owner
+  const showShopSection = isOwner || isMechanic;
+  const shopNav = OWNER_NAV;
 
-  const roleLabel = isAdmin ? 'Administrator' : 'Shop Owner';
+  const roleLabel = isAdmin ? 'Administrator' : isOwner ? 'Shop Owner' : 'Mechanic';
   const displayName = user?.full_name || user?.username || 'User';
   const initials = displayName.charAt(0).toUpperCase();
 

--- a/src/core/api/apiConstants.ts
+++ b/src/core/api/apiConstants.ts
@@ -22,9 +22,6 @@ export const API = {
     PRODUCT: (shopId: number, pid: number) => `/shops/${shopId}/products/${pid}`,
     SERVICES: (id: number) => `/shops/${id}/services`,
     SERVICE: (shopId: number, sid: number) => `/shops/${shopId}/services/${sid}`,
-    MECHANICS_PERFORMANCE: (id: number) => `/shops/${id}/mechanics/performance`,
-    MECHANICS_PERFORMANCE_TOP: (id: number) => `/shops/${id}/mechanics/performance/top`,
-    MY_PERFORMANCE: (id: number) => `/shops/${id}/mechanics/my-performance`,
   },
   MECHANIC: {
     PENDING_BOOKINGS: (shopId: number) => `/mechanic/shops/${shopId}/pending-bookings`,
@@ -36,6 +33,8 @@ export const API = {
     ORDER_READY: (shopId: number, orderId: number) => `/mechanic/shops/${shopId}/orders/${orderId}/ready`,
     NOTIFICATIONS: '/mechanic/my-notifications',
     NOTIFICATION_READ: (id: number) => `/mechanic/notifications/${id}/read`,
+    PERFORMANCE: (shopId: number) => `/shops/${shopId}/mechanics/performance`,
+    MECHANIC_PERFORMANCE: (shopId: number, mechanicId: number) => `/shops/${shopId}/mechanics/performance/${mechanicId}`,
   },
   QUOTATIONS: {
     SHOP_LIST: (shopId: number) => `/quotations/shops/${shopId}`,
@@ -49,12 +48,12 @@ export const API = {
     SHOP_DETAIL: (shopId: number, iId: number) => `/invoices/shops/${shopId}/${iId}`,
     CREATE: (shopId: number) => `/invoices/shops/${shopId}`,
     SEND: (shopId: number, iId: number) => `/invoices/shops/${shopId}/${iId}/send`,
-    PAYMENT: (shopId: number, iId: number) => `/invoices/shops/${shopId}/${iId}/payments`,
+    PAYMENT: (shopId: number, iId: number) => `/invoices/shops/${shopId}/${iId}/record-payment`,
   },
   REPAIR_PROGRESS: {
-    SHOP_LIST: (shopId: number) => `/repair-progress/shops/${shopId}`,
-    CREATE: (shopId: number) => `/repair-progress/shops/${shopId}`,
-    UPDATE: (shopId: number, pid: number) => `/repair-progress/shops/${shopId}/${pid}`,
+    GET: (shopId: number, apptId: number) => `/repair-progress/shops/${shopId}/appointments/${apptId}`,
+    CREATE: (shopId: number, apptId: number) => `/repair-progress/shops/${shopId}/appointments/${apptId}`,
+    ADVANCE: (shopId: number, apptId: number) => `/repair-progress/shops/${shopId}/appointments/${apptId}/update`,
   },
   ADMIN: {
     USERS: '/admin/users',
@@ -64,6 +63,7 @@ export const API = {
     USER_DELETE: (id: number) => `/admin/users/${id}`,
     SHOPS: '/admin/shops',
     SHOP: (id: number) => `/admin/shops/${id}`,
+    SHOP_STATUS: (id: number) => `/admin/shops/${id}/status`,
     SHOP_DELETE: (id: number) => `/admin/shops/${id}`,
     APPOINTMENTS: '/admin/appointments',
     ORDERS: '/admin/orders',
@@ -76,7 +76,5 @@ export const API = {
   CUSTOMERS: {
     SHOP_APPOINTMENTS: (shopId: number) => `/customers/shops/${shopId}/appointments`,
     APPT_STATUS: (shopId: number, apptId: number) => `/customers/shops/${shopId}/appointments/${apptId}/status`,
-    SHOP_ORDERS: (shopId: number) => `/product-orders/shops/${shopId}/orders`,
-    ORDER_STATUS: (shopId: number, orderId: number) => `/product-orders/shops/${shopId}/orders/${orderId}/status`,
   },
 } as const;

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -15,10 +15,16 @@ export interface UserProfile {
   created_at?: string;
 }
 
+export interface ShopRole {
+  shop_id: number;
+  role: string;
+}
+
 export interface UserRolesResponse {
   username: string;
   roles: string[];
   is_superuser: boolean;
+  shop_roles: ShopRole[];
 }
 
 // My Shops
@@ -49,10 +55,23 @@ export interface PaginatedResponse<T> {
 
 // Admin
 export interface AdminStats {
-  total_users: number;
-  total_shops: number;
-  total_appointments: number;
-  total_revenue: number;
+  users: { total: number; active: number; inactive: number; admins: number };
+  shops: { total: number; active: number; inactive: number };
+  catalog: { products: number; services: number };
+  appointments: { total: number; pending: number; completed: number; cancelled: number };
+  orders: { total: number; pending: number; completed: number; cancelled: number };
+  revenue: { appointments: number; orders: number; total: number };
+}
+
+export interface AdminDailyStats {
+  period_days: number;
+  start_date: string;
+  end_date: string;
+  new_users: number;
+  new_shops: number;
+  new_appointments: number;
+  new_orders: number;
+  revenue: { appointments: number; orders: number; total: number };
 }
 
 export interface AdminUser {
@@ -233,21 +252,21 @@ export interface Payment {
 // Repair Progress
 export type RepairStage =
   | 'received'
-  | 'diagnosing'
-  | 'waiting_parts'
-  | 'in_progress'
+  | 'diagnosed'
+  | 'parts_ordered'
+  | 'in_repair'
   | 'quality_check'
-  | 'ready_for_pickup'
-  | 'completed';
+  | 'ready'
+  | 'delivered';
 
 export const REPAIR_STAGES: RepairStage[] = [
   'received',
-  'diagnosing',
-  'waiting_parts',
-  'in_progress',
+  'diagnosed',
+  'parts_ordered',
+  'in_repair',
   'quality_check',
-  'ready_for_pickup',
-  'completed',
+  'ready',
+  'delivered',
 ];
 
 export interface RepairProgress {

--- a/src/pages/admin/AdminAppointmentsPage.tsx
+++ b/src/pages/admin/AdminAppointmentsPage.tsx
@@ -6,11 +6,18 @@ import { Badge, statusBadge } from '../../components/ui/Badge';
 import { Button } from '../../components/ui/Button';
 import type { AdminAppointment, PaginatedResponse } from '../../core/types';
 
+const STATUSES = ['', 'pending', 'confirmed', 'in_progress', 'completed', 'cancelled', 'rejected'] as const;
+
 export function AdminAppointmentsPage() {
   const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState('');
   const limit = 20;
+
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+  if (statusFilter) params.set('status', statusFilter);
+
   const { data, loading, error, refetch } = useFetch<PaginatedResponse<AdminAppointment>>(
-    `${API.ADMIN.APPOINTMENTS}?skip=${(page - 1) * limit}&limit=${limit}`
+    `${API.ADMIN.APPOINTMENTS}?${params}`
   );
 
   const appointments: AdminAppointment[] = data?.items ?? (Array.isArray(data) ? (data as AdminAppointment[]) : []);
@@ -20,8 +27,17 @@ export function AdminAppointmentsPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between items-center">
-        <p className="text-sm text-gray-500">Total: {total}</p>
+      <div className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 flex flex-wrap gap-3 items-center">
+        <select
+          value={statusFilter}
+          onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
+          className="rounded-lg border border-gray-300 px-3 py-2 text-sm bg-white focus:outline-none focus:border-blue-500"
+        >
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>{s === '' ? 'All Statuses' : s.replace('_', ' ')}</option>
+          ))}
+        </select>
+        <p className="flex-1 text-sm text-gray-500">Total: {total}</p>
         <Button variant="secondary" size="sm" onClick={refetch}>Refresh</Button>
       </div>
       <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">

--- a/src/pages/admin/AdminDashboardPage.tsx
+++ b/src/pages/admin/AdminDashboardPage.tsx
@@ -1,77 +1,144 @@
+import { useState } from 'react';
 import { useFetch } from '../../hooks/useFetch';
 import { API } from '../../core/api/apiConstants';
 import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
-import type { AdminStats } from '../../core/types';
+import type { AdminStats, AdminDailyStats } from '../../core/types';
 
-function StatCard({ label, value, icon, color }: { label: string; value: string | number; icon: React.ReactNode; color: string }) {
+function StatCard({ label, value, sub, icon, color }: { label: string; value: string | number; sub?: string; icon: React.ReactNode; color: string }) {
   return (
-    <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100 flex items-center gap-4">
-      <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${color}`}>{icon}</div>
-      <div>
-        <p className="text-sm text-gray-500">{label}</p>
+    <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100 flex items-center gap-4">
+      <div className={`w-11 h-11 rounded-xl flex items-center justify-center flex-shrink-0 ${color}`}>{icon}</div>
+      <div className="min-w-0">
+        <p className="text-xs text-gray-500 font-medium">{label}</p>
         <p className="text-2xl font-bold text-gray-900 mt-0.5">{value}</p>
+        {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
       </div>
     </div>
   );
 }
 
+function DeltaCard({ label, value, prefix = '' }: { label: string; value: number; prefix?: string }) {
+  return (
+    <div className="bg-white rounded-xl p-5 shadow-sm border border-gray-100 text-center">
+      <p className="text-2xl font-bold text-gray-900">{prefix}{value.toLocaleString()}</p>
+      <p className="text-xs text-gray-500 mt-1">{label}</p>
+    </div>
+  );
+}
+
+const DAY_OPTIONS = [7, 30, 90] as const;
+type DayOption = typeof DAY_OPTIONS[number];
+
+const fmt = (n: number) =>
+  `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
 export function AdminDashboardPage() {
-  const { data, loading, error } = useFetch<AdminStats>(API.ADMIN.STATISTICS);
+  const [days, setDays] = useState<DayOption>(30);
 
-  if (loading) return <LoadingSpinner />;
-  if (error) return <div className="text-red-600 bg-red-50 rounded-lg p-4">{error}</div>;
+  const { data: stats, loading: statsLoading, error: statsError } =
+    useFetch<AdminStats>(API.ADMIN.STATISTICS);
 
-  const stats = data ?? { total_users: 0, total_shops: 0, total_appointments: 0, total_revenue: 0 };
+  const { data: daily, loading: dailyLoading, error: dailyError } =
+    useFetch<AdminDailyStats>(`${API.ADMIN.STATISTICS_DAILY}?days=${days}`);
+
+  if (statsLoading) return <LoadingSpinner />;
+  if (statsError) return <div className="text-red-600 bg-red-50 rounded-lg p-4">{statsError}</div>;
+  if (!stats) return null;
 
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard
-          label="Total Users"
-          value={stats.total_users}
-          color="bg-blue-100"
-          icon={
-            <svg className="w-6 h-6 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-          }
-        />
-        <StatCard
-          label="Total Shops"
-          value={stats.total_shops}
-          color="bg-purple-100"
-          icon={
-            <svg className="w-6 h-6 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5" />
-            </svg>
-          }
-        />
-        <StatCard
-          label="Total Appointments"
-          value={stats.total_appointments}
-          color="bg-yellow-100"
-          icon={
-            <svg className="w-6 h-6 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
-          }
-        />
-        <StatCard
-          label="Total Revenue"
-          value={`$${Number(stats.total_revenue).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-          color="bg-green-100"
-          icon={
-            <svg className="w-6 h-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          }
-        />
+
+      {/* Platform totals */}
+      <div>
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">Platform Totals</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <StatCard
+            label="Users"
+            value={stats.users.total}
+            sub={`${stats.users.active} active · ${stats.users.admins} admins`}
+            color="bg-blue-100"
+            icon={<svg className="w-5 h-5 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" /></svg>}
+          />
+          <StatCard
+            label="Shops"
+            value={stats.shops.total}
+            sub={`${stats.shops.active} active · ${stats.shops.inactive} inactive`}
+            color="bg-purple-100"
+            icon={<svg className="w-5 h-5 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5" /></svg>}
+          />
+          <StatCard
+            label="Appointments"
+            value={stats.appointments.total}
+            sub={`${stats.appointments.pending} pending · ${stats.appointments.completed} done`}
+            color="bg-yellow-100"
+            icon={<svg className="w-5 h-5 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>}
+          />
+          <StatCard
+            label="Total Revenue"
+            value={fmt(stats.revenue.total)}
+            sub={`Appts ${fmt(stats.revenue.appointments)} · Orders ${fmt(stats.revenue.orders)}`}
+            color="bg-green-100"
+            icon={<svg className="w-5 h-5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>}
+          />
+        </div>
+
+        {/* Catalog strip */}
+        <div className="mt-4 grid grid-cols-2 gap-4">
+          <div className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 flex items-center justify-between">
+            <span className="text-sm text-gray-500">Products listed</span>
+            <span className="font-bold text-gray-900">{stats.catalog.products.toLocaleString()}</span>
+          </div>
+          <div className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 flex items-center justify-between">
+            <span className="text-sm text-gray-500">Services listed</span>
+            <span className="font-bold text-gray-900">{stats.catalog.services.toLocaleString()}</span>
+          </div>
+        </div>
       </div>
 
-      <div className="bg-white rounded-xl p-6 shadow-sm border border-gray-100">
-        <h2 className="text-base font-semibold text-gray-900 mb-1">Quick Actions</h2>
-        <p className="text-sm text-gray-500">Use the sidebar to navigate to Users, Shops, Appointments, or Orders management.</p>
+      {/* Period stats */}
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider">
+            Last {days} Days
+            {daily && (
+              <span className="ml-2 font-normal normal-case text-gray-400">
+                ({new Date(daily.start_date).toLocaleDateString()} – {new Date(daily.end_date).toLocaleDateString()})
+              </span>
+            )}
+          </h2>
+          <div className="flex gap-1">
+            {DAY_OPTIONS.map((d) => (
+              <button
+                key={d}
+                onClick={() => setDays(d)}
+                className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
+                  days === d ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {d}d
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {dailyLoading ? (
+          <div className="bg-white rounded-xl p-8 shadow-sm border border-gray-100 flex justify-center">
+            <LoadingSpinner />
+          </div>
+        ) : dailyError ? (
+          <div className="text-red-600 bg-red-50 rounded-lg p-4 text-sm">{dailyError}</div>
+        ) : daily ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
+            <DeltaCard label="New Users" value={daily.new_users} />
+            <DeltaCard label="New Shops" value={daily.new_shops} />
+            <DeltaCard label="New Appointments" value={daily.new_appointments} />
+            <DeltaCard label="New Orders" value={daily.new_orders} />
+            <DeltaCard label="Appt Revenue" value={daily.revenue.appointments} prefix="$" />
+            <DeltaCard label="Total Revenue" value={daily.revenue.total} prefix="$" />
+          </div>
+        ) : null}
       </div>
+
     </div>
   );
 }

--- a/src/pages/admin/AdminRatingsPage.tsx
+++ b/src/pages/admin/AdminRatingsPage.tsx
@@ -1,32 +1,57 @@
+import { useState } from 'react';
 import { useFetch } from '../../hooks/useFetch';
 import { apiClient } from '../../core/api/apiClient';
 import { API } from '../../core/api/apiConstants';
 import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
 import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
 
 interface RatingItem {
   id: number;
   rating: number;
   review?: string;
-  type: 'product' | 'service';
-  item_name?: string;
+  comment?: string;
   user_id?: number;
+  product_id?: number;
+  service_id?: number;
+  item_name?: string;
   created_at?: string;
+  // injected client-side
+  type: 'product' | 'service';
 }
 
-interface RatingsData {
+interface RatingsResponse {
+  product_ratings?: RatingItem[];
+  service_ratings?: RatingItem[];
+  // fallback if backend wraps in items
   items?: RatingItem[];
-  total?: number;
 }
+
+const LIMIT = 100;
 
 export function AdminRatingsPage() {
-  const { data, loading, error, refetch } = useFetch<RatingsData>(API.ADMIN.RATINGS);
-  const ratings: RatingItem[] = data?.items ?? (Array.isArray(data) ? (data as RatingItem[]) : []);
+  const [skip, setSkip] = useState(0);
+  const [typeFilter, setTypeFilter] = useState<'all' | 'product' | 'service'>('all');
+
+  const { data, loading, error, refetch } = useFetch<RatingsResponse>(
+    `${API.ADMIN.RATINGS}?skip=${skip}&limit=${LIMIT}`
+  );
+
+  // Normalise the two-array shape the API returns
+  const productRatings: RatingItem[] = (data?.product_ratings ?? []).map(r => ({ ...r, type: 'product' as const }));
+  const serviceRatings: RatingItem[] = (data?.service_ratings ?? []).map(r => ({ ...r, type: 'service' as const }));
+  const allRatings: RatingItem[] = [...productRatings, ...serviceRatings];
+
+  const ratings = typeFilter === 'all'
+    ? allRatings
+    : allRatings.filter(r => r.type === typeFilter);
 
   const deleteRating = async (r: RatingItem) => {
     if (!confirm('Delete this rating?')) return;
     try {
-      const url = r.type === 'product' ? API.ADMIN.RATING_PRODUCT_DELETE(r.id) : API.ADMIN.RATING_SERVICE_DELETE(r.id);
+      const url = r.type === 'product'
+        ? API.ADMIN.RATING_PRODUCT_DELETE(r.id)
+        : API.ADMIN.RATING_SERVICE_DELETE(r.id);
       await apiClient.delete(url);
       refetch();
     } catch (e: unknown) {
@@ -34,43 +59,79 @@ export function AdminRatingsPage() {
     }
   };
 
-  const stars = (n: number) => '★'.repeat(n) + '☆'.repeat(5 - n);
+  const stars = (n: number) => '★'.repeat(Math.max(0, Math.min(5, n))) + '☆'.repeat(5 - Math.max(0, Math.min(5, n)));
+
+  const page = Math.floor(skip / LIMIT) + 1;
+  const hasNext = allRatings.length === LIMIT;
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
+      <div className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 flex flex-wrap gap-3 items-center">
+        {/* Type filter */}
+        <div className="flex gap-1">
+          {(['all', 'product', 'service'] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTypeFilter(t)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium capitalize transition-colors ${
+                typeFilter === t ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <p className="flex-1 text-sm text-gray-500">
+          {ratings.length} rating{ratings.length !== 1 ? 's' : ''}
+          {typeFilter !== 'all' && ` (${typeFilter})`}
+        </p>
         <Button variant="secondary" size="sm" onClick={refetch}>Refresh</Button>
       </div>
+
       <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
         {loading ? <LoadingSpinner /> : error ? <div className="p-6 text-red-600">{error}</div> : (
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b">
-              <tr>
-                {['ID', 'Type', 'Item', 'User', 'Rating', 'Review', 'Date', 'Actions'].map((h) => (
-                  <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {ratings.map((r) => (
-                <tr key={`${r.type}-${r.id}`} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 text-gray-500">{r.id}</td>
-                  <td className="px-4 py-3 capitalize text-gray-700">{r.type}</td>
-                  <td className="px-4 py-3 text-gray-700">{r.item_name ?? '—'}</td>
-                  <td className="px-4 py-3 text-gray-500">{r.user_id ?? '—'}</td>
-                  <td className="px-4 py-3 text-yellow-500 font-mono">{stars(r.rating)}</td>
-                  <td className="px-4 py-3 text-gray-600 max-w-xs truncate">{r.review ?? '—'}</td>
-                  <td className="px-4 py-3 text-gray-500">{r.created_at ? new Date(r.created_at).toLocaleDateString() : '—'}</td>
-                  <td className="px-4 py-3">
-                    <button onClick={() => deleteRating(r)} className="text-red-600 hover:underline text-xs">Delete</button>
-                  </td>
+          <>
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  {['ID', 'Type', 'Item', 'User', 'Rating', 'Review', 'Date', 'Actions'].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">{h}</th>
+                  ))}
                 </tr>
-              ))}
-              {ratings.length === 0 && (
-                <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-400">No ratings found</td></tr>
-              )}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {ratings.map((r) => (
+                  <tr key={`${r.type}-${r.id}`} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-500">{r.id}</td>
+                    <td className="px-4 py-3">
+                      <Badge variant={r.type === 'product' ? 'default' : 'info'}>
+                        {r.type}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-gray-700">{r.item_name ?? (r.product_id ? `Product #${r.product_id}` : r.service_id ? `Service #${r.service_id}` : '—')}</td>
+                    <td className="px-4 py-3 text-gray-500">{r.user_id ?? '—'}</td>
+                    <td className="px-4 py-3 text-yellow-500 font-mono text-xs">{stars(r.rating)}</td>
+                    <td className="px-4 py-3 text-gray-600 max-w-xs truncate">{r.review ?? r.comment ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-500">{r.created_at ? new Date(r.created_at).toLocaleDateString() : '—'}</td>
+                    <td className="px-4 py-3">
+                      <button onClick={() => deleteRating(r)} className="text-red-600 hover:underline text-xs">Delete</button>
+                    </td>
+                  </tr>
+                ))}
+                {ratings.length === 0 && (
+                  <tr><td colSpan={8} className="px-4 py-8 text-center text-gray-400">No ratings found</td></tr>
+                )}
+              </tbody>
+            </table>
+
+            <div className="px-4 py-3 border-t flex items-center justify-between text-sm text-gray-500">
+              <span>Page {page}</span>
+              <div className="flex gap-2">
+                <Button variant="secondary" size="sm" disabled={skip === 0} onClick={() => setSkip(s => Math.max(0, s - LIMIT))}>Prev</Button>
+                <Button variant="secondary" size="sm" disabled={!hasNext} onClick={() => setSkip(s => s + LIMIT)}>Next</Button>
+              </div>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/pages/admin/AdminShopsPage.tsx
+++ b/src/pages/admin/AdminShopsPage.tsx
@@ -9,14 +9,27 @@ import type { Shop, PaginatedResponse } from '../../core/types';
 
 export function AdminShopsPage() {
   const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
   const limit = 20;
-  // Admin API uses skip/limit (offset-based), same as /admin/users
+
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+  if (search) params.set('search', search);
+
   const { data, loading, error, refetch } = useFetch<PaginatedResponse<Shop>>(
-    `${API.ADMIN.SHOPS}?skip=${(page - 1) * limit}&limit=${limit}`
+    `${API.ADMIN.SHOPS}?${params}`
   );
 
   const shops: Shop[] = data?.items ?? (Array.isArray(data) ? (data as Shop[]) : []);
   const total = data?.total ?? shops.length;
+
+  const toggleShopStatus = async (shop: Shop) => {
+    try {
+      await apiClient.put(`${API.ADMIN.SHOP_STATUS(shop.id)}?is_active=${!shop.is_active}`);
+      refetch();
+    } catch (e: unknown) {
+      alert((e as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed to update shop status');
+    }
+  };
 
   const deleteShop = async (shop: Shop) => {
     if (!confirm(`Delete shop "${shop.name}"? This cannot be undone.`)) return;
@@ -30,8 +43,14 @@ export function AdminShopsPage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between items-center">
-        <p className="text-sm text-gray-500">Total: {total} shops</p>
+      <div className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 flex flex-wrap gap-3">
+        <input
+          type="text"
+          placeholder="Search by name..."
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+          className="flex-1 min-w-48 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+        />
         <Button variant="secondary" size="sm" onClick={refetch}>Refresh</Button>
       </div>
 
@@ -64,7 +83,15 @@ export function AdminShopsPage() {
                       </Badge>
                     </td>
                     <td className="px-4 py-3">
-                      <button onClick={() => deleteShop(shop)} className="text-red-600 hover:underline text-xs">Delete</button>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => toggleShopStatus(shop)}
+                          className={`text-xs hover:underline ${shop.is_active ? 'text-yellow-600' : 'text-green-600'}`}
+                        >
+                          {shop.is_active ? 'Deactivate' : 'Activate'}
+                        </button>
+                        <button onClick={() => deleteShop(shop)} className="text-red-600 hover:underline text-xs">Delete</button>
+                      </div>
                     </td>
                   </tr>
                 ))}

--- a/src/pages/admin/UsersPage.tsx
+++ b/src/pages/admin/UsersPage.tsx
@@ -20,7 +20,7 @@ export function UsersPage() {
   const [page, setPage] = useState(1);
   const limit = 20;
 
-  const params = new URLSearchParams({ skip: String((page - 1) * limit), limit: String(limit) });
+  const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (search) params.set('search', search);
   if (filterActive !== '') params.set('is_active', filterActive);
 
@@ -35,7 +35,7 @@ export function UsersPage() {
   const toggleStatus = async (user: AdminUser) => {
     setActing(true);
     try {
-      await apiClient.put(API.ADMIN.USER_STATUS(user.id), { is_active: !user.is_active });
+      await apiClient.put(`${API.ADMIN.USER_STATUS(user.id)}?is_active=${!user.is_active}`);
       refetch();
     } finally {
       setActing(false);
@@ -46,7 +46,7 @@ export function UsersPage() {
     if (!roleModal) return;
     setActing(true);
     try {
-      await apiClient.put(API.ADMIN.USER_ROLE(roleModal.id), { roles: newRole });
+      await apiClient.put(`${API.ADMIN.USER_ROLE(roleModal.id)}?is_superuser=${newRole === 'admin'}`);
       setRoleModal(null);
       refetch();
     } finally {
@@ -171,8 +171,7 @@ export function UsersPage() {
             onChange={(e) => setNewRole(e.target.value)}
           >
             <option value="user">User</option>
-            <option value="mechanic">Mechanic</option>
-            <option value="owner">Owner</option>
+            <option value="admin">Admin (superuser)</option>
           </Select>
           <div className="flex justify-end gap-2">
             <Button variant="secondary" onClick={() => setRoleModal(null)}>Cancel</Button>

--- a/src/pages/owner/OrdersPage.tsx
+++ b/src/pages/owner/OrdersPage.tsx
@@ -10,9 +10,6 @@ import { Modal } from '../../components/ui/Modal';
 import { Textarea } from '../../components/ui/Input';
 import type { PendingOrder } from '../../core/types';
 
-const STATUS_FILTERS = ['all', 'pending', 'confirmed', 'processing', 'ready', 'completed', 'cancelled'] as const;
-type StatusFilter = typeof STATUS_FILTERS[number];
-
 interface OrdersData {
   orders?: PendingOrder[];
   count?: number;
@@ -20,13 +17,7 @@ interface OrdersData {
 
 export function OrdersPage() {
   const { shopId } = useAuth();
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('pending');
-
-  const url = shopId
-    ? statusFilter === 'all'
-      ? API.CUSTOMERS.SHOP_ORDERS(shopId)
-      : `${API.CUSTOMERS.SHOP_ORDERS(shopId)}?order_status=${statusFilter}`
-    : null;
+  const url = shopId ? API.MECHANIC.PENDING_ORDERS(shopId) : null;
 
   const { data, loading, error, refetch } = useFetch<OrdersData | PendingOrder[]>(url);
 
@@ -87,23 +78,6 @@ export function OrdersPage() {
 
   return (
     <div className="space-y-4">
-      {/* Status filter tabs */}
-      <div className="flex flex-wrap gap-2">
-        {STATUS_FILTERS.map((s) => (
-          <button
-            key={s}
-            onClick={() => setStatusFilter(s)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium capitalize transition-colors ${
-              statusFilter === s
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            }`}
-          >
-            {s}
-          </button>
-        ))}
-      </div>
-
       <div className="flex items-center justify-between">
         <p className="text-sm text-gray-500">{orders.length} order{orders.length !== 1 ? 's' : ''}</p>
         <Button variant="secondary" size="sm" onClick={refetch}>Refresh</Button>
@@ -157,7 +131,7 @@ export function OrdersPage() {
           ))}
           {orders.length === 0 && (
             <div className="bg-white rounded-xl p-12 text-center text-gray-400 shadow-sm border border-gray-100">
-              No {statusFilter === 'all' ? '' : statusFilter} orders
+              No pending orders
             </div>
           )}
         </div>

--- a/src/pages/owner/PerformancePage.tsx
+++ b/src/pages/owner/PerformancePage.tsx
@@ -12,12 +12,12 @@ function StarRating({ rating }: { rating?: number }) {
 }
 
 export function PerformancePage() {
-  const { shopId, isOwner, isAdmin } = useAuth();
-  // Owners/admins see full team performance; mechanics see own
+  const { shopId, user, isOwner, isAdmin } = useAuth();
+  // Owners/admins see full team performance; mechanics see their own record
   const url = shopId && (isOwner || isAdmin)
-    ? API.SHOPS.MECHANICS_PERFORMANCE(shopId)
-    : shopId
-    ? API.SHOPS.MY_PERFORMANCE(shopId)
+    ? API.MECHANIC.PERFORMANCE(shopId)
+    : shopId && user
+    ? API.MECHANIC.MECHANIC_PERFORMANCE(shopId, user.id)
     : null;
 
   const { data, loading, error, refetch } = useFetch<PerformanceResponse | MechanicStats[]>(url);
@@ -38,7 +38,9 @@ export function PerformancePage() {
         <Button variant="secondary" size="sm" onClick={refetch}>Refresh</Button>
       </div>
 
-      {loading ? <LoadingSpinner /> : error ? <div className="text-red-600 bg-red-50 rounded-lg p-4">{error}</div> : (
+      {loading ? <LoadingSpinner /> : (error && error !== 'Not Found') ? (
+        <div className="text-red-600 bg-red-50 rounded-lg p-4">{error}</div>
+      ) : (
         <>
           {/* Summary */}
           {summary && (
@@ -92,9 +94,9 @@ export function PerformancePage() {
             </div>
           )}
 
-          {isTeam && mechanics.length === 0 && !loading && (
+          {(error === 'Not Found' || (!loading && isTeam && mechanics.length === 0)) && (
             <div className="bg-white rounded-xl p-12 text-center text-gray-400 shadow-sm border border-gray-100">
-              No performance data available
+              No performance data recorded yet
             </div>
           )}
         </>

--- a/src/pages/owner/RepairProgressPage.tsx
+++ b/src/pages/owner/RepairProgressPage.tsx
@@ -1,34 +1,30 @@
 import { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
-import { useFetch } from '../../hooks/useFetch';
 import { apiClient } from '../../core/api/apiClient';
 import { API } from '../../core/api/apiConstants';
-import { LoadingSpinner } from '../../components/ui/LoadingSpinner';
 import { Button } from '../../components/ui/Button';
 import { Modal } from '../../components/ui/Modal';
-import { Input, Select, Textarea } from '../../components/ui/Input';
+import { Select, Textarea } from '../../components/ui/Input';
 import { REPAIR_STAGES, type RepairProgress, type RepairStage } from '../../core/types';
-
-interface RepairsData { repairs?: RepairProgress[]; items?: RepairProgress[] }
 
 const STAGE_LABELS: Record<RepairStage, string> = {
   received: 'Received',
-  diagnosing: 'Diagnosing',
-  waiting_parts: 'Waiting Parts',
-  in_progress: 'In Progress',
+  diagnosed: 'Diagnosed',
+  parts_ordered: 'Parts Ordered',
+  in_repair: 'In Repair',
   quality_check: 'Quality Check',
-  ready_for_pickup: 'Ready for Pickup',
-  completed: 'Completed',
+  ready: 'Ready',
+  delivered: 'Delivered',
 };
 
 const STAGE_COLORS: Record<RepairStage, string> = {
-  received: 'bg-gray-200',
-  diagnosing: 'bg-blue-400',
-  waiting_parts: 'bg-yellow-400',
-  in_progress: 'bg-orange-400',
+  received: 'bg-gray-300',
+  diagnosed: 'bg-blue-400',
+  parts_ordered: 'bg-yellow-400',
+  in_repair: 'bg-orange-400',
   quality_check: 'bg-purple-400',
-  ready_for_pickup: 'bg-green-400',
-  completed: 'bg-green-600',
+  ready: 'bg-green-400',
+  delivered: 'bg-green-600',
 };
 
 function StageProgress({ stage }: { stage: RepairStage }) {
@@ -49,134 +45,160 @@ function StageProgress({ stage }: { stage: RepairStage }) {
 
 export function RepairProgressPage() {
   const { shopId } = useAuth();
-  const [stageFilter, setStageFilter] = useState<RepairStage | ''>('');
+  const [apptIdInput, setApptIdInput] = useState('');
+  const [apptId, setApptId] = useState<number | null>(null);
+  const [repair, setRepair] = useState<RepairProgress | null>(null);
+  const [fetchError, setFetchError] = useState('');
+  const [fetching, setFetching] = useState(false);
 
-  const url = shopId
-    ? `${API.REPAIR_PROGRESS.SHOP_LIST(shopId)}${stageFilter ? `?stage=${stageFilter}` : ''}`
-    : null;
-  const { data, loading, error, refetch } = useFetch<RepairsData | RepairProgress[]>(url);
-
-  const [createModal, setCreateModal] = useState(false);
-  const [updateModal, setUpdateModal] = useState<RepairProgress | null>(null);
-  const [createForm, setCreateForm] = useState({ appointment_id: '', stage: 'received' as RepairStage, description: '', estimated_completion: '' });
-  const [updateForm, setUpdateForm] = useState({ stage: 'received' as RepairStage, note: '', estimated_completion: '' });
+  const [startModal, setStartModal] = useState(false);
+  const [advanceModal, setAdvanceModal] = useState(false);
+  const [startForm, setStartForm] = useState({ stage: 'received' as RepairStage, notes: '' });
+  const [advanceForm, setAdvanceForm] = useState({ stage: 'diagnosed' as RepairStage, notes: '' });
   const [saving, setSaving] = useState(false);
 
-  const repairs: RepairProgress[] = Array.isArray(data) ? data : (data as RepairsData)?.repairs ?? (data as RepairsData)?.items ?? [];
-
-  const createRepair = async () => {
-    if (!shopId) return;
-    setSaving(true);
+  const lookupRepair = async () => {
+    const id = parseInt(apptIdInput);
+    if (!shopId || !id) return;
+    setFetching(true);
+    setFetchError('');
+    setRepair(null);
+    setApptId(id);
     try {
-      await apiClient.post(API.REPAIR_PROGRESS.CREATE(shopId), {
-        ...createForm,
-        appointment_id: parseInt(createForm.appointment_id),
-        estimated_completion: createForm.estimated_completion || undefined,
-      });
-      setCreateModal(false);
-      refetch();
+      const res = await apiClient.get<RepairProgress>(API.REPAIR_PROGRESS.GET(shopId, id));
+      setRepair(res.data);
     } catch (e: unknown) {
-      alert((e as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed');
-    } finally { setSaving(false); }
+      const detail = (e as { response?: { data?: { detail?: string }; status?: number } });
+      if (detail.response?.status === 404) {
+        setFetchError('No repair tracking found for this appointment.');
+      } else {
+        setFetchError(detail.response?.data?.detail ?? 'Failed to fetch repair progress');
+      }
+    } finally {
+      setFetching(false);
+    }
   };
 
-  const openUpdate = (r: RepairProgress) => {
-    setUpdateForm({ stage: r.stage, note: '', estimated_completion: '' });
-    setUpdateModal(r);
-  };
-
-  const updateRepair = async () => {
-    if (!updateModal || !shopId) return;
+  const startRepair = async () => {
+    if (!shopId || !apptId) return;
     setSaving(true);
     try {
-      await apiClient.put(API.REPAIR_PROGRESS.UPDATE(shopId, updateModal.id), {
-        ...updateForm,
-        estimated_completion: updateForm.estimated_completion || undefined,
-      });
-      setUpdateModal(null);
-      refetch();
+      const res = await apiClient.post<RepairProgress>(API.REPAIR_PROGRESS.CREATE(shopId, apptId), startForm);
+      setRepair(res.data);
+      setStartModal(false);
     } catch (e: unknown) {
-      alert((e as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed');
-    } finally { setSaving(false); }
+      alert((e as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed to start repair');
+    } finally {
+      setSaving(false); }
+  };
+
+  const advanceRepair = async () => {
+    if (!shopId || !apptId) return;
+    setSaving(true);
+    try {
+      const res = await apiClient.post<RepairProgress>(API.REPAIR_PROGRESS.ADVANCE(shopId, apptId), advanceForm);
+      setRepair(res.data);
+      setAdvanceModal(false);
+    } catch (e: unknown) {
+      alert((e as { response?: { data?: { detail?: string } } }).response?.data?.detail ?? 'Failed to advance stage');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openAdvance = () => {
+    if (!repair) return;
+    const nextIdx = Math.min(REPAIR_STAGES.indexOf(repair.stage) + 1, REPAIR_STAGES.length - 1);
+    setAdvanceForm({ stage: REPAIR_STAGES[nextIdx], notes: '' });
+    setAdvanceModal(true);
   };
 
   if (!shopId) return <div className="text-gray-500">No shop selected.</div>;
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <p className="text-sm text-gray-500">{repairs.length} repair{repairs.length !== 1 ? 's' : ''}</p>
-          <select
-            value={stageFilter}
-            onChange={(e) => setStageFilter(e.target.value as RepairStage | '')}
-            className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm bg-white focus:outline-none focus:border-blue-500"
-          >
-            <option value="">All Stages</option>
-            {REPAIR_STAGES.map((s) => (
-              <option key={s} value={s}>{STAGE_LABELS[s]}</option>
-            ))}
-          </select>
+      {/* Appointment lookup */}
+      <div className="bg-white rounded-xl p-4 shadow-sm border border-gray-100 flex gap-3 items-end">
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-gray-600 mb-1">Appointment ID</label>
+          <input
+            type="number"
+            value={apptIdInput}
+            onChange={(e) => setApptIdInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && lookupRepair()}
+            placeholder="Enter appointment ID..."
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+          />
         </div>
-        <div className="flex gap-2">
-          <Button variant="secondary" size="sm" onClick={refetch}>Refresh</Button>
-          <Button size="sm" onClick={() => setCreateModal(true)}>+ Start Repair</Button>
-        </div>
+        <Button onClick={lookupRepair} loading={fetching} disabled={!apptIdInput}>Look Up</Button>
       </div>
 
-      {loading ? <LoadingSpinner /> : error ? <div className="text-red-600 bg-red-50 rounded-lg p-4">{error}</div> : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {repairs.map((r) => (
-            <div key={r.id} className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-              <div className="flex items-start justify-between mb-3">
-                <div>
-                  <p className="font-semibold text-gray-900">Repair #{r.id}</p>
-                  {r.appointment_id && <p className="text-xs text-gray-500">Appointment #{r.appointment_id}</p>}
-                </div>
-                <Button size="sm" variant="secondary" onClick={() => openUpdate(r)}>Update Stage</Button>
-              </div>
-              <StageProgress stage={r.stage} />
-              {r.description && <p className="text-sm text-gray-600 mt-3">{r.description}</p>}
-              {r.estimated_completion && (
-                <p className="text-xs text-gray-500 mt-1">Est. completion: {new Date(r.estimated_completion).toLocaleString()}</p>
+      {/* Result */}
+      {fetchError && (
+        <div className="bg-red-50 rounded-xl p-4 text-red-600 text-sm flex items-center justify-between">
+          <span>{fetchError}</span>
+          {fetchError.includes('No repair') && (
+            <Button size="sm" onClick={() => setStartModal(true)}>Start Tracking</Button>
+          )}
+        </div>
+      )}
+
+      {repair && (
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 space-y-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="font-semibold text-gray-900">Appointment #{apptId}</p>
+              <p className="text-xs text-gray-500 mt-0.5">Current stage: {STAGE_LABELS[repair.stage]}</p>
+            </div>
+            <div className="flex gap-2">
+              {repair.stage !== 'delivered' && (
+                <Button size="sm" onClick={openAdvance}>Advance Stage</Button>
               )}
             </div>
-          ))}
-          {repairs.length === 0 && (
-            <div className="col-span-2 bg-white rounded-xl p-12 text-center text-gray-400 shadow-sm border border-gray-100">
-              No active repairs
+          </div>
+          <StageProgress stage={repair.stage} />
+          {repair.description && <p className="text-sm text-gray-600">{repair.description}</p>}
+          {repair.updates && repair.updates.length > 0 && (
+            <div className="border-t pt-3">
+              <p className="text-xs font-medium text-gray-500 mb-2">History</p>
+              <div className="space-y-1">
+                {repair.updates.map((u) => (
+                  <div key={u.id} className="text-xs text-gray-600 flex gap-2">
+                    <span className="text-gray-400">{u.created_at ? new Date(u.created_at).toLocaleString() : ''}</span>
+                    <span>{STAGE_LABELS[u.from_stage]} → {STAGE_LABELS[u.to_stage]}</span>
+                    {u.note && <span className="text-gray-500">— {u.note}</span>}
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>
       )}
 
-      {/* Create Modal */}
-      <Modal isOpen={createModal} onClose={() => setCreateModal(false)} title="Start Repair Progress" size="sm">
+      {/* Start Modal */}
+      <Modal isOpen={startModal} onClose={() => setStartModal(false)} title="Start Repair Tracking" size="sm">
         <div className="space-y-4">
-          <Input label="Appointment ID *" type="number" value={createForm.appointment_id} onChange={(e) => setCreateForm({ ...createForm, appointment_id: e.target.value })} placeholder="1" />
-          <Select label="Initial Stage" value={createForm.stage} onChange={(e) => setCreateForm({ ...createForm, stage: e.target.value as RepairStage })}>
+          <Select label="Initial Stage" value={startForm.stage} onChange={(e) => setStartForm({ ...startForm, stage: e.target.value as RepairStage })}>
             {REPAIR_STAGES.map((s) => <option key={s} value={s}>{STAGE_LABELS[s]}</option>)}
           </Select>
-          <Textarea label="Description" rows={2} value={createForm.description} onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })} placeholder="Vehicle received for inspection..." />
-          <Input label="Est. Completion (optional)" type="datetime-local" value={createForm.estimated_completion} onChange={(e) => setCreateForm({ ...createForm, estimated_completion: e.target.value })} />
+          <Textarea label="Notes (optional)" rows={2} value={startForm.notes} onChange={(e) => setStartForm({ ...startForm, notes: e.target.value })} placeholder="Vehicle received for inspection..." />
           <div className="flex justify-end gap-2">
-            <Button variant="secondary" onClick={() => setCreateModal(false)}>Cancel</Button>
-            <Button onClick={createRepair} loading={saving} disabled={!createForm.appointment_id}>Start</Button>
+            <Button variant="secondary" onClick={() => setStartModal(false)}>Cancel</Button>
+            <Button onClick={startRepair} loading={saving}>Start</Button>
           </div>
         </div>
       </Modal>
 
-      {/* Update Modal */}
-      <Modal isOpen={!!updateModal} onClose={() => setUpdateModal(null)} title={`Update Repair #${updateModal?.id}`} size="sm">
+      {/* Advance Modal */}
+      <Modal isOpen={advanceModal} onClose={() => setAdvanceModal(false)} title="Advance Repair Stage" size="sm">
         <div className="space-y-4">
-          <Select label="New Stage" value={updateForm.stage} onChange={(e) => setUpdateForm({ ...updateForm, stage: e.target.value as RepairStage })}>
+          <Select label="New Stage" value={advanceForm.stage} onChange={(e) => setAdvanceForm({ ...advanceForm, stage: e.target.value as RepairStage })}>
             {REPAIR_STAGES.map((s) => <option key={s} value={s}>{STAGE_LABELS[s]}</option>)}
           </Select>
-          <Textarea label="Note (optional)" rows={2} value={updateForm.note} onChange={(e) => setUpdateForm({ ...updateForm, note: e.target.value })} placeholder="Engine repair started..." />
-          <Input label="Est. Completion (optional)" type="datetime-local" value={updateForm.estimated_completion} onChange={(e) => setUpdateForm({ ...updateForm, estimated_completion: e.target.value })} />
+          <Textarea label="Note (optional)" rows={2} value={advanceForm.notes} onChange={(e) => setAdvanceForm({ ...advanceForm, notes: e.target.value })} placeholder="Engine repair started..." />
           <div className="flex justify-end gap-2">
-            <Button variant="secondary" onClick={() => setUpdateModal(null)}>Cancel</Button>
-            <Button onClick={updateRepair} loading={saving}>Update</Button>
+            <Button variant="secondary" onClick={() => setAdvanceModal(false)}>Cancel</Button>
+            <Button onClick={advanceRepair} loading={saving}>Advance</Button>
           </div>
         </div>
       </Modal>


### PR DESCRIPTION
…atures

- Fix all admin list pages to use ?page= instead of ?skip= pagination
- Fix AdminStats type and dashboard to use nested API response shape
- Add daily statistics section to admin dashboard with 7d/30d/90d selector
- Fix AdminRatingsPage to handle separate product_ratings/service_ratings arrays, add skip/limit pagination and type filter
- Fix AdminShopsPage: add search filter and Deactivate/Activate toggle (PUT /admin/shops/{id}/status)
- Fix AdminAppointmentsPage: add status filter dropdown including rejected
- Fix UsersPage: status toggle and role change now use query params instead of body
- Fix invoice payment path: /payments → /record-payment
- Fix performance endpoints to correct /shops/{id}/mechanics/performance path
- Redesign RepairProgressPage around appointment-scoped API; fix all 7 stage names
- Fix OrdersPage to use MECHANIC.PENDING_ORDERS instead of non-existent CUSTOMERS.SHOP_ORDERS
- Remove non-existent CUSTOMERS.SHOP_ORDERS/ORDER_STATUS constants
- Add ADMIN.SHOP_STATUS constant for new shop toggle endpoint
- Sidebar: hide Shop Management section for pure admins (isOwner || isMechanic only)
- Handle 404 as empty state on PerformancePage
- Add ShopRole to UserRolesResponse type; add AdminDailyStats type